### PR TITLE
Bugfix!  Wrong loop index variable.

### DIFF
--- a/src/ll_alloc.c
+++ b/src/ll_alloc.c
@@ -5861,7 +5861,7 @@ static void **ialloc_fallback(atls *tl, size_t n, size_t *sizes, void **chunks, 
 fail:
 	for (n = 0; n < i; n++)
 	{
-		PREFIX(free)(out[i]);
+		PREFIX(free)(out[n]);
 	}
 
 	if (!chunks) PREFIX(free)(out);


### PR DESCRIPTION
I was testing clang-tidy and found this.  The old code wouldn't have been likely to be run or cause too much trouble -- it's in a fallback allocator's error path for specific values of n -- but a double-free (attempt to free released memory) could occur as out[i] could be freed multiple times.  The real index here is n, not i.